### PR TITLE
Fix performance issue - Batchnormalization

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3907,7 +3907,7 @@ def _postprocess_convnd_output(x, data_format):
 def _preprocess_convnd_kernel(kernel, data_format):
     # Kernel is always provided in TF kernel shape: (rows, cols, input_depth, depth)
     # Convert it to MXNet kernel shape: (depth, input_depth, rows, cols)
-    if len(kernel.shape) > 3:
+    if data_format == 'channels_last' and len(kernel.shape) > 3:
         kernel = KerasSymbol(mx.sym.transpose(data=kernel.symbol, axes=(3, 2, 0, 1)))
 
     return kernel
@@ -3961,6 +3961,10 @@ def _convnd(x, kernel, strides, filter_dilation, name=None, padding_mode='valid'
             data_format='default'):
     if data_format is None or data_format == 'default':
         data_format = image_data_format()
+
+    if data_format == 'channels_last':
+        warnings.warn("MXNet Backend performs best with 'channels_first' format. Using 'channels_last' will "
+                      "significantly reduce performance due to the Transpose operations.", stacklevel=2)
 
     # Handle Data Format
     x = _preprocess_convnd_input(x, data_format)

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
+import warnings
 import mxnet as mx
 import numpy as np
 from numbers import Number
@@ -1872,7 +1873,7 @@ def batch_normalization(x, mean, var, beta, gamma, epsilon=1e-3):
 
 
 @keras_mxnet_symbol
-def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=-1, epsilon=1e-3):
+def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=1, epsilon=1e-3):
     """Apply native  MXNet batch normalization on x with given moving_mean,
     moving_var, beta and gamma.
 
@@ -1882,6 +1883,9 @@ def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=
         beta: Tensor by which to center the input.
         moving_mean: Moving mean.
         moving_var: Moving variance.
+        momentum: Moving average momentum. Defaults to 0.9
+        axis: Axis along which Batchnorm is applied. Axis usually represent axis of 'channels'. MXNet follows
+        'channels_first' hence, defaults to '1'.
         epsilon: Fuzz factor to avoid divide by zero.
 
     # Returns
@@ -1897,6 +1901,10 @@ def mxnet_batchnorm(x, gamma, beta, moving_mean, moving_var, momentum=0.9, axis=
         beta = beta.symbol
     if isinstance(gamma, KerasSymbol):
         gamma = gamma.symbol
+
+    if axis != 1:
+        warnings.warn("MXNet Backend uses 'channels_first' format. Axis for BatchNorm should ideally be '1'."
+                      "Provided - '" + axis + "'. Performance can be significantly lower!", stacklevel=2)
 
     return KerasSymbol(
         mx.sym.BatchNorm(x, gamma, beta, moving_mean,

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -129,7 +129,13 @@ class _Conv(Layer):
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
         input_dim = input_shape[channel_axis]
-        kernel_shape = self.kernel_size + (input_dim, self.filters)
+
+        if self.data_format == 'channels_first':
+            kernel_shape = (self.filters, input_dim) + self.kernel_size
+        else:
+            kernel_shape = self.kernel_size + (input_dim, self.filters)
+
+        #kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.kernel = self.add_weight(shape=kernel_shape,
                                       initializer=self.kernel_initializer,

--- a/keras/layers/normalization.py
+++ b/keras/layers/normalization.py
@@ -74,7 +74,6 @@ class BatchNormalization(Layer):
                  **kwargs):
         super(BatchNormalization, self).__init__(**kwargs)
         self.supports_masking = True
-        self.axis = axis
         self.momentum = momentum
         self.epsilon = epsilon
         self.center = center
@@ -87,6 +86,11 @@ class BatchNormalization(Layer):
         self.gamma_regularizer = regularizers.get(gamma_regularizer)
         self.beta_constraint = constraints.get(beta_constraint)
         self.gamma_constraint = constraints.get(gamma_constraint)
+
+        if axis == -1 and K.image_data_format() == 'channels_first':
+            self.axis = 1
+        else:
+            self.axis = axis
 
     def build(self, input_shape):
         dim = input_shape[self.axis]

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -843,10 +843,13 @@ class TestBackend(object):
     def test_conv2d(self):
         # TF kernel shape: (rows, cols, input_depth, depth)
         # channels_first input shape: (n, input_depth, rows, cols)
+        # Kernels are expected to always be channels_last for KTF, KC and KTH.
+        # Kernels should be channels_first if data_format is channels_first for KMX.
+
         for input_shape in [(2, 3, 4, 5), (2, 3, 5, 6)]:
             for kernel_shape in [(2, 2, 3, 4), (4, 3, 3, 4)]:
                 check_two_tensor_operation('conv2d', input_shape, kernel_shape,
-                                           BACKENDS, cntk_dynamicity=True,
+                                           BACKENDS_WITHOUT_MXNET, cntk_dynamicity=True,
                                            data_format='channels_first')
         input_shape = (1, 6, 5, 3)
         kernel_shape = (3, 3, 3, 2)


### PR DESCRIPTION
Fix performance issue with Batchnorm layer.
This fix significantly reduce the performance difference between Keras+MXNet and MXNet alone.
All UTs/ITs pass.

Benchmarked on Resnet56 - CIFAR10 with this fix.

On CPU
Keras-MXNet is around 8% slower than MXNet 
On GPU
Keras-MXNet is around 12% slower than MXNet.