### PR TITLE
Conv3d() operator implementation for Keras2.0 using MXNet backend

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3041,10 +3041,10 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
         data_format = image_data_format()
     _validate_data_format(data_format)
 
-    if padding not in {"same", "valid"}:
-        raise ValueError("`padding` should be either `same` or `valid`.")
+    if padding not in {'same', 'valid'}:
+        raise ValueError('`padding` should be either `same` or `valid`.')
 
-    return _convnd(x, kernel, name="conv3d", strides=strides, filter_dilation=dilation_rate,
+    return _convnd(x, kernel, name='conv3d', strides=strides, filter_dilation=dilation_rate,
                    padding_mode=padding, data_format=data_format)
 
 
@@ -3932,11 +3932,11 @@ def _postprocess_convnd_output(x, data_format):
 @keras_mxnet_symbol
 def _preprocess_convnd_kernel(kernel, data_format):
     # Kernel is always provided in TF kernel shape:
-    #   2-D data: (rows, cols, input_depth, depth)
-    #   3-D date: (kernel_depth, kernel_height, kernel_width, input_depth, depth)
+    #   2-D: (rows, cols, input_depth, depth)
+    #   3-D: (kernel_depth, kernel_rows, kernel_cols, input_depth, depth)
     # Convert it to MXNet kernel shape:
     #   2-D: (depth, input_depth, rows, cols)
-    #   3-D: (depth, input_depth, kernel_depth, kernel_height, kernel_width)
+    #   3-D: (depth, input_depth, kernel_depth, kernel_rows, kernel_cols)
     #
     if len(kernel.shape) > 4:
         kernel = KerasSymbol(mx.sym.transpose(data=kernel.symbol, axes=(4, 3, 0, 1, 2)))

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3037,7 +3037,15 @@ def conv3d(x, kernel, strides=(1, 1, 1), padding='valid',
     # Raises
         ValueError: if `data_format` is neither `channels_last` or `channels_first`.
     """
-    raise NotImplementedError('MXNet Backend: conv3d operator is not supported yet.')
+    if data_format is None:
+        data_format = image_data_format()
+    _validate_data_format(data_format)
+
+    if padding not in {"same", "valid"}:
+        raise ValueError("`padding` should be either `same` or `valid`.")
+
+    return _convnd(x, kernel, name="conv3d", strides=strides, filter_dilation=dilation_rate,
+                   padding_mode=padding, data_format=data_format)
 
 
 def conv3d_transpose(x, kernel, output_shape, strides=(1, 1, 1),
@@ -3923,9 +3931,16 @@ def _postprocess_convnd_output(x, data_format):
 
 @keras_mxnet_symbol
 def _preprocess_convnd_kernel(kernel, data_format):
-    # Kernel is always provided in TF kernel shape: (rows, cols, input_depth, depth)
-    # Convert it to MXNet kernel shape: (depth, input_depth, rows, cols)
-    if len(kernel.shape) > 3:
+    # Kernel is always provided in TF kernel shape:
+    #   2-D data: (rows, cols, input_depth, depth)
+    #   3-D date: (kernel_depth, kernel_height, kernel_width, input_depth, depth)
+    # Convert it to MXNet kernel shape:
+    #   2-D: (depth, input_depth, rows, cols)
+    #   3-D: (depth, input_depth, kernel_depth, kernel_height, kernel_width)
+    #
+    if data_format == 'channels_last' and len(kernel.shape) > 4:
+        kernel = KerasSymbol(mx.sym.transpose(data=kernel.symbol, axes=(4, 3, 0, 1, 2)))
+    elif data_format == 'channels_last' and len(kernel.shape) > 3:
         kernel = KerasSymbol(mx.sym.transpose(data=kernel.symbol, axes=(3, 2, 0, 1)))
 
     return kernel

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -3938,9 +3938,9 @@ def _preprocess_convnd_kernel(kernel, data_format):
     #   2-D: (depth, input_depth, rows, cols)
     #   3-D: (depth, input_depth, kernel_depth, kernel_height, kernel_width)
     #
-    if data_format == 'channels_last' and len(kernel.shape) > 4:
+    if len(kernel.shape) > 4:
         kernel = KerasSymbol(mx.sym.transpose(data=kernel.symbol, axes=(4, 3, 0, 1, 2)))
-    elif data_format == 'channels_last' and len(kernel.shape) > 3:
+    elif len(kernel.shape) > 3:
         kernel = KerasSymbol(mx.sym.transpose(data=kernel.symbol, axes=(3, 2, 0, 1)))
 
     return kernel

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-        -n 2
+#        -n 2
         --durations=10
 
 # Do not run tests in the build folder

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 # Configuration of py.test
 [pytest]
 addopts=-v
-#        -n 2
+        -n 2
         --durations=10
 
 # Do not run tests in the build folder

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -848,8 +848,6 @@ class TestBackend(object):
         # TH kernel shape: (depth, input_depth, x, y, z)
         # TF kernel shape: (x, y, z, input_depth, depth)
 
-        # MXNet backend does not support conv2d yet.
-
         # test in data_format = channels_first
         for input_shape in [(2, 3, 4, 5, 4), (2, 3, 5, 4, 6)]:
             for kernel_shape in [(2, 2, 2, 3, 4), (3, 2, 4, 3, 4)]:
@@ -861,13 +859,13 @@ class TestBackend(object):
         input_shape = (1, 2, 2, 2, 1)
         kernel_shape = (2, 2, 2, 1, 1)
         check_two_tensor_operation('conv3d', input_shape, kernel_shape,
-                                   BACKENDS_WITHOUT_MXNET, cntk_dynamicity=True,
+                                   BACKENDS, cntk_dynamicity=True,
                                    data_format='channels_last')
 
         xval = np.random.random(input_shape)
         kernel_val = np.random.random(kernel_shape) - 0.5
         # Test invalid use cases
-        for k in BACKENDS_WITHOUT_MXNET:
+        for k in BACKENDS:
             with pytest.raises(ValueError):
                 k.conv3d(k.variable(xval), k.variable(kernel_val), data_format='channels_middle')
 

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -440,9 +440,8 @@ def test_convolution_3d():
                                'kernel_size': 3,
                                'padding': padding,
                                'strides': strides},
-                       input_shape=(num_samples,
-                                    input_len_dim1, input_len_dim2, input_len_dim3,
-                                    stack_size))
+                       input_shape=(num_samples, stack_size,
+                                    input_len_dim1, input_len_dim2, input_len_dim3))
 
     layer_test(convolutional.Convolution3D,
                kwargs={'filters': filters,
@@ -458,7 +457,6 @@ def test_convolution_3d():
                input_shape=(num_samples,
                             input_len_dim1, input_len_dim2, input_len_dim3,
                             stack_size))
-
 
 @pytest.mark.skipif((K.backend() == 'mxnet'),
                     reason='MXNet backend does not support conv3d_transpose yet.')

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -420,8 +420,6 @@ def test_averagepooling_2d():
                input_shape=(3, 4, 5, 6))
 
 
-@pytest.mark.skipif((K.backend() == 'mxnet'),
-                    reason='MXNet backend does not support conv3d yet.')
 @keras_test
 def test_convolution_3d():
     num_samples = 2


### PR DESCRIPTION
Tested with existing convolution 3D example in keras/test directory and also with an end-to-end model on a manually generated dataset.

@sandeep-krishnamurthy  @roywei 