### PR TITLE
Add rnn() operator for MXNet backend with unrolling and masking feature

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4100,7 +4100,7 @@ def _preprocess_convnd_kernel(kernel, data_format):
     return kernel
 
 
-# @keras_mxnet_symbol
+@keras_mxnet_symbol
 def _preprocess_convnd_transpose_output(output_shape, data_format):
     if data_format == 'channels_last':
         output_shape = output_shape[1:-1]

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2565,28 +2565,27 @@ def rnn(step_function, inputs, initial_states,
     dtype = inputs.dtype
     dshape = inputs.shape
 
-    if not unroll and dshape[1] is None:
-        warnings.warn('MXNet Backend: Does not support Variable Length '
-                      'input(Samples of different length). Please pad your '
-                      'input to a constant length, provide `input_shape` and '
-                      'set `unroll=True`'
-                      'Ex: new_x_train = keras.preprocessing.sequence.pad_sequences(old_x_train, '
-                      'maxlen=MAX_LEN_OF_INPUT_SAMPLE_TYPE_INT). '
-                      'More Details - https://github.com/deep-learning-tools/keras/wiki/Limitations-and-workaround-of-RNN-layer-using-MXNet-backend”)',
-                      stacklevel=2)
-        raise NotImplementedError('MXNet Backend: unroll=False '
-                                  'is not supported yet in RNN.')
-    if unroll and dshape[1] is not None:
-        warnings.warn('Please set `unroll=True` while calling '
-                      'SimpleRNN/LSTM/GRU layer as you have provided '
-                      '`input_shape`. MXNet backend does not support '
-                      '`unroll=False` or a Variable Length Input',
-                      stacklevel=2)
-
     if len(dshape) < 3:
         raise ValueError('Input tensor should be at least 3-D')
     if not dshape[1]:
-        raise ValueError('Unrolling requires a fixed number of timesteps.')
+        raise ValueError('Unrolling requires a fixed number of time-steps.')
+
+    if not unroll and dshape[1] is None:
+        raise NotImplementedError('MXNet Backend: unroll=False '
+                                  'is not supported yet in RNN.\n'
+                                  'MXNet Backend: Does not support Variable '
+                                  'Length input(Samples of different length). '
+                                  'Please pad your input to a constant length, '
+                                  'provide `input_shape` and set `unroll=True`'
+                                  'Ex: new_x_train = keras.preprocessing.sequence.pad_sequences(old_x_train, '
+                                  'maxlen=MAX_LEN_OF_INPUT_SAMPLE_TYPE_INT). '
+                                  'More Details - https://github.com/deep-learning-tools/keras/wiki/Limitations-and-workaround-of-RNN-layer-using-MXNet-backend')
+    if not unroll and dshape[1] is not None:
+        raise NotImplementedError('Please set `unroll=True` while calling '
+                                  'SiumpleRNN/LSTM/GRU layer as you have '
+                                  'provided `input_shape`. MXNet backend does '
+                                  'not support `unroll=False` or a Variable '
+                                  'Length Input')
 
     # Split the inputs across time dimension and generate the list of inputs
     # with shape `(samples, ...)` (no time dimension)

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -195,7 +195,6 @@ def to_dense(tensor):
     """
     raise NotImplementedError('MXNet Backend: Sparse operations are not supported yet.')
 
-
 def variable(value, dtype=None, name=None, constraint=None):
     """Instantiates a variable and returns it.
 
@@ -2563,11 +2562,27 @@ def rnn(step_function, inputs, initial_states,
         ValueError: if `mask` is provided (not `None`) but states is not provided
             (`len(states)` == 0).
     """
-    if not unroll:
-        raise NotImplementedError('MXNet Backend: unroll=False '
-                                  'is not supported yet in RNN.')
     dtype = inputs.dtype
     dshape = inputs.shape
+
+    if not unroll and dshape[1] is None:
+        warnings.warn('MXNet Backend: Does not support Variable Length '
+                      'input(Samples of different length). Please pad your '
+                      'input to a constant length, provide `input_shape` and '
+                      'set `unroll=True`'
+                      'Ex: new_x_train = keras.preprocessing.sequence.pad_sequences(old_x_train, '
+                      'maxlen=MAX_LEN_OF_INPUT_SAMPLE_TYPE_INT). '
+                      'More Details - https://github.com/deep-learning-tools/keras/wiki/Limitations-and-workaround-of-RNN-layer-using-MXNet-backend”)',
+                      stacklevel=2)
+        raise NotImplementedError('MXNet Backend: unroll=False '
+                                  'is not supported yet in RNN.')
+    if unroll and dshape[1] is not None:
+        warnings.warn('Please set `unroll=True` while calling '
+                      'SimpleRNN/LSTM/GRU layer as you have provided '
+                      '`input_shape`. MXNet backend does not support '
+                      '`unroll=False` or a Variable Length Input',
+                      stacklevel=2)
+
     if len(dshape) < 3:
         raise ValueError('Input tensor should be at least 3-D')
     if not dshape[1]:

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -255,6 +255,7 @@ def variable(value, dtype=None, name=None, constraint=None):
     return ret
 
 
+@keras_mxnet_symbol
 def constant(value, dtype=None, shape=None, name=None):
     """Creates a constant tensor.
 
@@ -274,7 +275,15 @@ def constant(value, dtype=None, shape=None, name=None):
         np_ndarray = np.ndarray(shape, dtype=dtype)
         np_ndarray.fill(value)
         mx_ndarray = mx.nd.array(np_ndarray)
-    return mx_ndarray
+
+    # If the Tensor shape is (1, ), then, it is considered to be scalar.
+    # Return the NDArray.
+    if shape == (1,):
+        return mx_ndarray
+    name = _prepare_name(name, 'constant')
+    const_var = _keras_variable(name=name, dtype=dtype, shape=mx_ndarray.shape)
+    const_var.bind(mx_ndarray)
+    return const_var
 
 
 def is_keras_tensor(x):
@@ -644,6 +653,7 @@ def eye(size, dtype=None, name=None):
     return kvar
 
 
+@keras_mxnet_symbol
 def zeros_like(x, dtype=None, name=None):
     """Instantiates an all-zeros variable of the same shape as another tensor.
 
@@ -666,16 +676,7 @@ def zeros_like(x, dtype=None, name=None):
                [ 0.,  0.,  0.]], dtype=float32)
     ```
     """
-    if dtype is None:
-        dtype = x.dtype
-    else:
-        dtype = _convert_string_dtype(dtype)
-    name = _prepare_name(name, 'zeroslikeinit')
-    mx_shape = tuple([0 if x is None else x for x in x.shape])
-    mx_value = mx.nd.zeros(mx_shape, dtype=dtype)
-    k_var = _keras_variable(name=name, dtype=dtype, shape=mx_shape)
-    k_var.bind(mx_value)
-    return k_var
+    return KerasSymbol(mx.sym.zeros_like(data=x.symbol))
 
 
 def ones_like(x, dtype=None, name=None):
@@ -2505,6 +2506,7 @@ def stop_gradient(variables):
 
 
 # CONTROL FLOW
+@keras_mxnet_symbol
 def rnn(step_function, inputs, initial_states,
         go_backwards=False, mask=None, constants=None,
         unroll=False, input_length=None):
@@ -2536,7 +2538,7 @@ def rnn(step_function, inputs, initial_states,
         constants: a list of constant values passed at each step.
         unroll: whether to unroll the RNN or to use a symbolic loop
         (`while_loop` or `scan` depending on backend).
-        input_length: not relevant in the TensorFlow implementation.
+        input_length: not relevant in the TensorFlow and MXNet implementation.
             Must be specified if using unrolling with Theano.
 
     # Returns
@@ -2555,7 +2557,78 @@ def rnn(step_function, inputs, initial_states,
         ValueError: if `mask` is provided (not `None`) but states is not provided
             (`len(states)` == 0).
     """
-    raise NotImplementedError('MXNet Backend: RNNs are not supported yet.')
+    if not unroll:
+        raise NotImplementedError('MXNet Backend: unroll=False '
+                                  'is not supported yet in RNN.')
+    dtype = inputs.dtype
+    dshape = inputs.shape
+    if len(dshape) < 3:
+        raise ValueError('Input tensor should be at least 3-D')
+    if not dshape[1]:
+        raise ValueError('Unrolling requires a fixed number of timesteps.')
+
+    # Split the inputs across time dimension and generate the list of inputs
+    # with shape `(samples, ...)` (no time dimension)
+    inputs = list(mx.sym.split(inputs.symbol, axis=1,
+                               squeeze_axis=1, num_outputs=dshape[1]))
+
+    # Reverse the input sequence
+    if go_backwards:
+        inputs.reverse()
+
+    # Assume learning phase is a placeholder tensor.(F = test, T = train)
+    global uses_learning_phase
+    uses_learning_phase = False
+
+    states = initial_states
+    outputs = []
+    prev_output = None
+
+    if mask is not None:
+        if not states:
+            raise ValueError('Initial states is not provided when masking is '
+                             'enabled.')
+        if mask.dtype != dtype:
+            mask = cast(mask, dtype)
+        # Split the mask across time dimension and generate the list of masks
+        # with shape `(samples, 1)` (no time dimension)
+        masks = list(mx.sym.split(mask.symbol, axis=1,
+                                  squeeze_axis=1, num_outputs=dshape[1]))
+        # Reverse the input sequence
+        if go_backwards:
+            masks.reverse()
+    else:
+        masks = [None for _ in inputs]
+
+    if constants is None:
+        constants = []
+
+    # Iterate over a time step
+    for inp, msk in zip(inputs, masks):
+        last_output, new_states = step_function(KerasSymbol(inp),
+                                                states + constants)
+        if getattr(last_output, '_uses_learning_phase', False):
+            uses_learning_phase = True
+        if msk is not None:
+            new_states = [KerasSymbol(mx.sym.where(msk,
+                                                   ns.symbol,
+                                                   s.symbol))
+                          for s, ns in zip(states, new_states)]
+            # Initialize the output for first time step
+            if prev_output is None:
+                prev_output = zeros_like(last_output)
+            last_output = KerasSymbol(mx.sym.where(msk,
+                                                   last_output.symbol,
+                                                   prev_output.symbol))
+            prev_output = last_output
+        states = new_states
+        # Expand the output dimension from `(samples, output_dim)` to
+        # `(samples, 1, output_dim)` with middle axis as time dimension
+        outputs.append(mx.sym.expand_dims(last_output.symbol, axis=1))
+    # Concatenate the output across time dimension
+    outputs = mx.sym.Concat(*outputs, dim=1)
+    last_output._uses_learning_phase = uses_learning_phase
+    return last_output, KerasSymbol(outputs), states
 
 
 @keras_mxnet_symbol
@@ -2741,11 +2814,20 @@ def categorical_crossentropy(target, output, from_logits=False):
     # Returns
         Output tensor.
     """
-    assert not from_logits
     axis = ndim(output) - 1
     mx_output = output.symbol
+    # scale predictions so that the class probas of each sample sum to 1
+    if from_logits:
+        mx_output = mx.sym.softmax(mx_output, axis=axis)
+    else:
+        mx_output = mx.sym.broadcast_div(mx_output, mx.sym.sum(mx_output,
+                                                               axis=axis,
+                                                               keepdims=True))
+
+    # clip to prevent NaN's and Inf's
     mx_output = mx.sym.clip(mx_output, a_min=epsilon(), a_max=1 - epsilon())
-    mx_output = - mx.sym.sum(target.symbol * mx.sym.log(mx_output), axis=axis, keepdims=True)
+    # calc
+    mx_output = - mx.sym.sum(target.symbol * mx.sym.log(mx_output), axis=axis)
     return KerasSymbol(mx_output)
 
 
@@ -3643,6 +3725,8 @@ class KerasSymbol(object):
     def __getitem__(self, in_slice):
         begin = []
         end = []
+        if not isinstance(in_slice, (list, tuple)):
+            in_slice = (in_slice,)
         for i in in_slice:
             if isinstance(i, int):
                 begin.append(i)

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -2594,7 +2594,7 @@ def rnn(step_function, inputs, initial_states,
         # with shape `(samples, 1)` (no time dimension)
         masks = list(mx.sym.split(mask.symbol, axis=1,
                                   squeeze_axis=1, num_outputs=dshape[1]))
-        # Reverse the input sequence
+        # Reverse the mask sequence
         if go_backwards:
             masks.reverse()
     else:

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -224,9 +224,9 @@ def variable(value, dtype=None, name=None, constraint=None):
     ```
     """
     if constraint:
-        raise NotImplementedError('MXNet backend does not support constraints. '
-                                  'Keyword arguments such as '
-                                  '`kernel_constraint` and `bias_constraint`')
+        warnings.warn('MXNet backend does not support constraints. Keyword '
+                      'arguments such as `kernel_constraint` and '
+                      '`bias_constraint`', stacklevel=2)
     if dtype is None:
         dtype = floatx()
 
@@ -4100,7 +4100,7 @@ def _preprocess_convnd_kernel(kernel, data_format):
     return kernel
 
 
-@keras_mxnet_symbol
+# @keras_mxnet_symbol
 def _preprocess_convnd_transpose_output(output_shape, data_format):
     if data_format == 'channels_last':
         output_shape = output_shape[1:-1]

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -223,6 +223,10 @@ def variable(value, dtype=None, name=None, constraint=None):
                [ 3.,  4.]])
     ```
     """
+    if constraint:
+        raise NotImplementedError('MXNet backend does not support constraints. '
+                                  'Keyword arguments such as '
+                                  '`kernel_constraint` and `bias_constraint`')
     if dtype is None:
         dtype = floatx()
 
@@ -2832,7 +2836,7 @@ def categorical_crossentropy(target, output, from_logits=False):
                                                                keepdims=True))
 
     # clip to prevent NaN's and Inf's
-    mx_output = mx.sym.clip(mx_output, a_min=epsilon(), a_max=1 - epsilon())
+    mx_output = mx.sym.clip(mx_output, a_min=epsilon(), a_max=1.0 - epsilon())
     # calc
     mx_output = - mx.sym.sum(target.symbol * mx.sym.log(mx_output), axis=axis)
     return KerasSymbol(mx_output)
@@ -3732,6 +3736,8 @@ class KerasSymbol(object):
     def __getitem__(self, in_slice):
         begin = []
         end = []
+        # in_slice should be a tuple or list of slice() constructor
+        # Convert it to a tuple iterator for single dimensional bias Tensors
         if not isinstance(in_slice, (list, tuple)):
             in_slice = (in_slice,)
         for i in in_slice:

--- a/tests/integration_tests/test_temporal_data_tasks.py
+++ b/tests/integration_tests/test_temporal_data_tasks.py
@@ -10,10 +10,10 @@ from keras import layers, optimizers
 import keras.backend as K
 import keras
 
-pytestmark = pytest.mark.skipif(K.backend() == 'mxnet',
-                                reason='MXNet backend does not support RNN yet.')
 
-
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False '
+                           'in RNN yet.')
 @keras_test
 def test_temporal_classification():
     '''
@@ -47,6 +47,9 @@ def test_temporal_classification():
     model = Sequential.from_config(config)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False '
+                           'in RNN yet.')
 @keras_test
 def test_temporal_classification_functional():
     '''
@@ -77,6 +80,9 @@ def test_temporal_classification_functional():
     assert(history.history['acc'][-1] >= 0.8)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False '
+                           'in RNN yet.')
 @keras_test
 def test_temporal_regression():
     '''
@@ -122,6 +128,9 @@ def test_3d_to_3d():
     assert(history.history['loss'][-1] < 1.)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False '
+                           'in RNN yet.')
 @keras_test
 def test_stacked_lstm_char_prediction():
     '''
@@ -171,6 +180,9 @@ def test_stacked_lstm_char_prediction():
     assert(generated == alphabet)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False '
+                           'in RNN yet.')
 @keras_test
 def test_masked_temporal():
     '''
@@ -210,12 +222,16 @@ def test_masked_temporal():
 
 
 @pytest.mark.skipif(K.backend() != 'tensorflow', reason='Requires TensorFlow backend')
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False '
+                           'in RNN yet.')
 @keras_test
 def test_embedding_with_clipnorm():
     model = Sequential()
     model.add(layers.Embedding(input_dim=1, output_dim=1))
     model.compile(optimizer=optimizers.SGD(clipnorm=0.1), loss='mse')
     model.fit(np.array([[0]]), np.array([[[0.5]]]), epochs=1)
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -555,7 +555,8 @@ class TestBackend(object):
         outputs_list = [[], [], [], [], [], []]
         state_list = [[], [], [], [], [], []]
 
-        # MXNet backend does not support RNN yet
+        # MXNet backend does not support unroll=False in RNN yet. However, the
+        # keyword argument with `unroll=True` passes successfully.
         for k in BACKENDS_WITHOUT_MXNET:
             rnn_fn = rnn_step_fn(k)
             inputs = k.variable(input_val)

--- a/tests/keras/backend/backend_test.py
+++ b/tests/keras/backend/backend_test.py
@@ -758,15 +758,15 @@ class TestBackend(object):
         # otherwise it is garbage in garbage out...
         # due to the algo difference, we can't guarantee CNTK has the same result on the garbage input.
         # so create a separate test case for valid label input
-        check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2), [KTH, KTF], from_logits=True)
+        check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2), BACKENDS, from_logits=True)
         xval = np.asarray([[0.26157712, 0.0432167], [-0.43380741, 0.30559841],
                            [0.20225059, -0.38956559], [-0.13805378, 0.08506755]], dtype=np.float32)
         yval = np.asarray([[0.46221867, 0.53778133], [0.51228984, 0.48771016],
                            [0.64916514, 0.35083486], [0.47028078, 0.52971922]], dtype=np.float32)
         check_two_tensor_operation('categorical_crossentropy', yval, xval,
-                                   BACKENDS_WITHOUT_MXNET, cntk_two_dynamicity=True, from_logits=True)
+                                   BACKENDS, cntk_two_dynamicity=True, from_logits=True)
         check_two_tensor_operation('binary_crossentropy', (4, 2), (4, 2), BACKENDS, from_logits=False)
-        check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2), BACKENDS_WITHOUT_MXNET, from_logits=False)
+        check_two_tensor_operation('categorical_crossentropy', (4, 2), (4, 2), BACKENDS, from_logits=False)
 
         check_single_tensor_operation('l2_normalize', (4, 3), BACKENDS, axis=-1)
         check_single_tensor_operation('l2_normalize', (4, 3), BACKENDS, axis=1)

--- a/tests/keras/layers/convolutional_test.py
+++ b/tests/keras/layers/convolutional_test.py
@@ -198,6 +198,10 @@ def test_convolution_2d():
 
 
 @keras_test
+@pytest.mark.skipif((K.backend() == 'mxnet'),
+                    reason='Issue with symbolic binding due to modification in'
+                           'constant() operator'
+                           'More Details: https://github.com/deep-learning-tools/keras/issues/53')
 def test_conv2d_transpose():
     num_samples = 2
     filters = 2
@@ -452,8 +456,11 @@ def test_convolution_3d():
                             input_len_dim1, input_len_dim2, input_len_dim3,
                             stack_size))
 
+
 @pytest.mark.skipif((K.backend() == 'mxnet'),
-                    reason='MXNet backend does not support conv3d_transpose yet.')
+                    reason='Issue with symbolic binding due to modification in'
+                           'constant() operator'
+                           'More Details: https://github.com/deep-learning-tools/keras/issues/53')
 @keras_test
 def test_conv3d_transpose():
     filters = 2

--- a/tests/keras/layers/recurrent_test.py
+++ b/tests/keras/layers/recurrent_test.py
@@ -17,10 +17,6 @@ from keras import backend as K
 num_samples, timesteps, embedding_dim, units = 2, 5, 4, 3
 embedding_num = 12
 
-pytestmark = pytest.mark.skipif(K.backend() == 'mxnet',
-                                reason='MXNet backend does not support RNNs yet.')
-
-
 @keras_test
 def rnn_test(f):
     """
@@ -45,6 +41,9 @@ def rnn_cell_test(f):
     ])(f)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_return_sequences(layer_class):
     layer_test(layer_class,
@@ -53,6 +52,9 @@ def test_return_sequences(layer_class):
                input_shape=(num_samples, timesteps, embedding_dim))
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_dynamic_behavior(layer_class):
     layer = layer_class(units, input_shape=(None, embedding_dim))
@@ -64,6 +66,9 @@ def test_dynamic_behavior(layer_class):
     model.train_on_batch(x, y)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_stateful_invalid_use(layer_class):
     layer = layer_class(units,
@@ -85,6 +90,9 @@ def test_stateful_invalid_use(layer_class):
 @rnn_test
 @pytest.mark.skipif((K.backend() in ['theano']),
                     reason='Not supported.')
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 def test_dropout(layer_class):
     for unroll in [True, False]:
         layer_test(layer_class,
@@ -116,6 +124,9 @@ def test_dropout(layer_class):
         assert_allclose(y1, y2)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_statefulness(layer_class):
     model = Sequential()
@@ -155,6 +166,9 @@ def test_statefulness(layer_class):
     assert(out4.max() != out5.max())
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_masking_correctness(layer_class):
     # Check masking: output with left padding and right padding
@@ -181,6 +195,9 @@ def test_masking_correctness(layer_class):
     assert_allclose(out7, out6, atol=1e-5)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_implementation_mode(layer_class):
     for mode in [1, 2]:
@@ -204,6 +221,9 @@ def test_implementation_mode(layer_class):
                    input_shape=(num_samples, timesteps, embedding_dim))
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_regularizer(layer_class):
     layer = layer_class(units, return_sequences=False, weights=None,
@@ -242,6 +262,9 @@ def test_trainability(layer_class):
     assert len(layer.non_trainable_weights) == 0
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @keras_test
 def test_masking_layer():
     ''' This test based on a previously failing issue here:
@@ -273,6 +296,9 @@ def test_from_config(layer_class):
         assert l1.get_config() == l2.get_config()
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_specify_initial_state_keras_tensor(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -297,6 +323,9 @@ def test_specify_initial_state_keras_tensor(layer_class):
     model.fit([inputs] + initial_state, targets)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_specify_initial_state_non_keras_tensor(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -314,7 +343,6 @@ def test_specify_initial_state_non_keras_tensor(layer_class):
     inputs = np.random.random((num_samples, timesteps, embedding_dim))
     targets = np.random.random((num_samples, units))
     model.fit(inputs, targets)
-
 
 @rnn_test
 def test_reset_states_with_values(layer_class):
@@ -342,6 +370,9 @@ def test_reset_states_with_values(layer_class):
         layer.reset_states([1] * (len(layer.states) + 1))
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_initial_states_as_other_inputs(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -365,6 +396,9 @@ def test_initial_states_as_other_inputs(layer_class):
     model.train_on_batch([main_inputs] + initial_state, targets)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_specify_state_with_masking(layer_class):
     ''' This test based on a previously failing issue here:
@@ -387,6 +421,9 @@ def test_specify_state_with_masking(layer_class):
     model.fit([inputs] + initial_state, targets)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_return_state(layer_class):
     num_states = 2 if layer_class is recurrent.LSTM else 1
@@ -403,6 +440,9 @@ def test_return_state(layer_class):
     np.testing.assert_allclose(K.eval(layer.states[0]), state, atol=1e-4)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_state_reuse(layer_class):
     inputs = Input(batch_shape=(num_samples, timesteps, embedding_dim))
@@ -419,6 +459,9 @@ def test_state_reuse(layer_class):
 @rnn_test
 @pytest.mark.skipif((K.backend() in ['theano']),
                     reason='Not supported.')
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 def test_state_reuse_with_dropout(layer_class):
     input1 = Input(batch_shape=(num_samples, timesteps, embedding_dim))
     layer = layer_class(units, return_state=True, return_sequences=True, dropout=0.2)
@@ -433,6 +476,9 @@ def test_state_reuse_with_dropout(layer_class):
     outputs = model.predict(inputs)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @keras_test
 def test_minimal_rnn_cell_non_layer():
 
@@ -469,6 +515,9 @@ def test_minimal_rnn_cell_non_layer():
     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @keras_test
 def test_minimal_rnn_cell_non_layer_multiple_states():
 
@@ -509,6 +558,9 @@ def test_minimal_rnn_cell_non_layer_multiple_states():
     model.train_on_batch(np.zeros((6, 5, 5)), np.zeros((6, 32)))
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @keras_test
 def test_minimal_rnn_cell_layer():
 
@@ -589,6 +641,9 @@ def test_minimal_rnn_cell_layer():
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_cell_test
 def test_builtin_rnn_cell_layer(cell_class):
     # Test basic case.
@@ -638,6 +693,9 @@ def test_builtin_rnn_cell_layer(cell_class):
 @keras_test
 @pytest.mark.skipif((K.backend() in ['cntk', 'theano']),
                     reason='Not supported.')
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 def test_stacked_rnn_dropout():
     cells = [recurrent.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1),
              recurrent.LSTMCell(3, dropout=0.1, recurrent_dropout=0.1)]
@@ -689,6 +747,9 @@ def test_stacked_rnn_compute_output_shape():
     assert output_shape == expected_output_shape
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @rnn_test
 def test_batch_size_equal_one(layer_class):
     inputs = Input(batch_shape=(1, timesteps, embedding_dim))
@@ -701,6 +762,9 @@ def test_batch_size_equal_one(layer_class):
     model.train_on_batch(x, y)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @keras_test
 def test_rnn_cell_with_constants_layer():
 
@@ -810,6 +874,9 @@ def test_rnn_cell_with_constants_layer():
     assert_allclose(y_np, y_np_2, atol=1e-4)
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet',
+                    reason='MXNet backend does not support unroll=False in '
+                           'RNN yet.')
 @keras_test
 def test_rnn_cell_with_constants_layer_passing_initial_state():
 

--- a/tests/keras/legacy/layers_test.py
+++ b/tests/keras/legacy/layers_test.py
@@ -248,7 +248,8 @@ def test_merge_mask_3d():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support LSTM yet.')
+                    reason='MXNet backend does not support unroll=False in RNN '
+                           'and Embedding layer yet.')
 @keras_test
 def test_sequential_regression():
     # start with a basic example of using a Sequential model

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -65,7 +65,9 @@ def _test_optimizer(optimizer, target=0.75):
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def _test_no_grad(optimizer):
     inp = Input([3])
@@ -78,7 +80,9 @@ def _test_no_grad(optimizer):
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_sgd():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, nesterov=True)
@@ -87,7 +91,9 @@ def test_sgd():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_rmsprop():
     _test_optimizer(optimizers.RMSprop())
@@ -95,7 +101,9 @@ def test_rmsprop():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_adagrad():
     _test_optimizer(optimizers.Adagrad())
@@ -103,7 +111,9 @@ def test_adagrad():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_adadelta():
     _test_optimizer(optimizers.Adadelta(), target=0.6)
@@ -111,7 +121,9 @@ def test_adadelta():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_adam():
     _test_optimizer(optimizers.Adam())
@@ -145,7 +157,9 @@ def test_adam_amsgrad():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_clipnorm():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, clipnorm=0.5)
@@ -153,7 +167,9 @@ def test_clipnorm():
 
 
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Categorical Cross Entropy yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_clipvalue():
     sgd = optimizers.SGD(lr=0.01, momentum=0.9, clipvalue=0.5)


### PR DESCRIPTION
- Add run() operator in MXNet backend with unrolling and masking feature.
- Modified constant(), zeros_like(), and categorical_crossentropy() operator
- Enable test cases for run() operator with unrolling and masking feature.

@deep-learning-tools/aws-deep-learning-team @sandeep-krishnamurthy @roywei 