### PR TITLE
Enable perf optimization in conv operator for mxnet backend

### DIFF
--- a/keras/backend/__init__.py
+++ b/keras/backend/__init__.py
@@ -18,7 +18,7 @@ if not os.access(_keras_base_dir, os.W_OK):
 _keras_dir = os.path.join(_keras_base_dir, '.keras')
 
 # Default backend: TensorFlow.
-_BACKEND = 'tensorflow'
+_BACKEND = 'mxnet'
 
 # Attempt to read Keras config file.
 _config_path = os.path.expanduser(os.path.join(_keras_dir, 'keras.json'))

--- a/keras/layers/convolutional.py
+++ b/keras/layers/convolutional.py
@@ -130,7 +130,10 @@ class _Conv(Layer):
                              'should be defined. Found `None`.')
         input_dim = input_shape[channel_axis]
 
-        kernel_shape = self.kernel_size + (input_dim, self.filters)
+        if self.data_format == 'channels_first':
+            kernel_shape = (self.filters, input_dim) + self.kernel_size
+        else:
+            kernel_shape = self.kernel_size + (input_dim, self.filters)
 
         self.kernel = self.add_weight(shape=kernel_shape,
                                       initializer=self.kernel_initializer,
@@ -727,7 +730,11 @@ class Conv2DTranspose(Conv2D):
             raise ValueError('The channel dimension of the inputs '
                              'should be defined. Found `None`.')
         input_dim = input_shape[channel_axis]
-        kernel_shape = self.kernel_size + (self.filters, input_dim)
+
+        if self.data_format == 'channels_first':
+            kernel_shape = (input_dim, self.filters) + self.kernel_size
+        else:
+            kernel_shape = self.kernel_size + (self.filters, input_dim)
 
         self.kernel = self.add_weight(shape=kernel_shape,
                                       initializer=self.kernel_initializer,

--- a/tests/keras/utils/layer_utils_test.py
+++ b/tests/keras/utils/layer_utils_test.py
@@ -10,6 +10,9 @@ from keras.utils import layer_utils
 from keras.utils.test_utils import keras_test
 
 
+@pytest.mark.skipif(K.backend() == 'mxnet', reason='Test assumes kernel in channels_last format always. MXNet backend '
+                                                   'has performance optimization that changes kernel from '
+                                                   '"channels_first" to "channels_last" based on image_data_format')
 @keras_test
 def test_convert_weights():
     def get_model(shape, data_format):


### PR DESCRIPTION
* Enable conv kernel to be of channels_first or channels_last based on user provided data_format. This makes conv operation with mxnet backend avoid many transpose operations due to always channels_last conv kernel enforced by keras engine.
* Make mxnet as default backend for Keras in this branch.

@deep-learning-tools/aws-deep-learning-team 