### PR TITLE
Add support for keras multi_gpu_model() API with MXNet backend

### DIFF
--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -99,7 +99,7 @@ def multi_gpu_model(model, gpus=None):
     rather than the model returned by `multi_gpu_model`.
     """
 
-    if K.backend() != 'tensorflow' and K.backend() != 'mxnet'):
+    if K.backend() != 'tensorflow' and K.backend() != 'mxnet':
         raise ValueError('`multi_gpu_model` is only available '
                          'with the TensorFlow and MXNet backend.')
 

--- a/keras/utils/training_utils.py
+++ b/keras/utils/training_utils.py
@@ -98,9 +98,14 @@ def multi_gpu_model(model, gpus=None):
     with the template model (the argument you passed to `multi_gpu_model`),
     rather than the model returned by `multi_gpu_model`.
     """
-    if K.backend() != 'tensorflow':
+
+    if K.backend() != 'tensorflow' and K.backend() != 'mxnet'):
         raise ValueError('`multi_gpu_model` is only available '
-                         'with the TensorFlow backend.')
+                         'with the TensorFlow and MXNet backend.')
+
+    if K.backend() == 'mxnet':
+        model.set_mxnet_context(gpus)
+        return model
 
     available_devices = _get_available_devices()
     available_devices = [_normalize_device_name(name) for name in available_devices]


### PR DESCRIPTION
This PR makes Keras-MXNet interface for one and multi-GPU training same across other backends.
Post this PR, no need to manually pass context param, however, it is still supported.

* Add support for keras multi_gpu_model() API with MXNet backend
* Autoset GPU0 context when running on GPU machine

Tested with Resnet50 on CIFAR with following settings:
1. No context -> Use first available GPU i.e., GPU0
2. compile with keras.training_utils.multi_gpu_model(model, gpus=4) -> Use 4 gpus i.e., GPU0, GPU1, GPU2, GPU3
3. compile with keras.training_utils.multi_gpu_model(model, gpus=[0, 3]) -> Use 2 gpus i.e., GPU0, GPU3

@deep-learning-tools/aws-deep-learning-team 