### PR TITLE
Adamax and NAdam optimizer for MXNet backend

### DIFF
--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4735,6 +4735,22 @@ def get_optimizers():
             base_config = super(Adamax, self).get_config()
             return dict(list(base_config.items()) + list(config.items()))
 
+    class Nadam(MXOptimizer, mx.optimizer.Nadam):
+        def __init__(self, lr=0.001, beta_1=0.9, beta_2=0.999, epsilon=1e-8, decay=0., clipnorm=None,
+                     schedule_decay=0.004, **kwargs):
+            mx.optimizer.Nadam.__init__(self, learning_rate=lr, beta1=beta_1, beta2=beta_2, epsilon=epsilon,
+                                        schedule_decay=schedule_decay, **kwargs)
+            MXOptimizer.__init__(self, lr, decay)
+
+        def get_config(self):
+            config = {'lr': float(get_value(self.learning_rate)),
+                      'beta_1': float(get_value(self.beta1)),
+                      'beta_2': float(get_value(self.beta2)),
+                      'epsilon': self.epsilon,
+                      'schedule_decay': self.schedule_decay}
+            base_config = super(Nadam, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
     class RMSprop(MXOptimizer, mx.optimizer.RMSProp):
         def __init__(self, lr=0.001, rho=0.9, epsilon=1e-8, decay=0., clipnorm=None, **kwargs):
             mx.optimizer.RMSProp.__init__(self, learning_rate=lr, gamma1=rho, epsilon=epsilon,
@@ -4749,4 +4765,4 @@ def get_optimizers():
             base_config = super(RMSprop, self).get_config()
             return dict(list(base_config.items()) + list(config.items()))
 
-    return SGD, Adagrad, Adadelta, Adam, Adamax, RMSprop
+    return SGD, Adagrad, Adadelta, Adam, Adamax, RMSprop, Nadam

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4718,6 +4718,20 @@ def get_optimizers():
             base_config = super(Adam, self).get_config()
             return dict(list(base_config.items()) + list(config.items()))
 
+    class Adamax(MXOptimizer, mx.optimizer.Adamax):
+        def __init__(self, learning_rate=0.002, beta1=0.9, beta2=0.999, decay=0., **kwargs):
+            mx.optimizer.Adamax.__init__(self, learning_rate=learning_rate, beta1=beta1, beta2=beta2,
+                                         **kwargs)
+            MXOptimizer.__init__(self, learning_rate, decay)
+
+        def get_config(self):
+            config = {'lr': float(get_value(self.learning_rate)),
+                      'beta_1': float(get_value(self.beta1)),
+                      'beta_2': float(get_value(self.beta2)),
+                      'decay': float(get_value(self.decay))}
+            base_config = super(Adamax, self).get_config()
+            return dict(list(base_config.items()) + list(config.items()))
+
     class RMSprop(MXOptimizer, mx.optimizer.RMSProp):
         def __init__(self, lr=0.001, rho=0.9, epsilon=1e-8, decay=0., clipnorm=None, **kwargs):
             mx.optimizer.RMSProp.__init__(self, learning_rate=lr, gamma1=rho, epsilon=epsilon,
@@ -4732,4 +4746,4 @@ def get_optimizers():
             base_config = super(RMSprop, self).get_config()
             return dict(list(base_config.items()) + list(config.items()))
 
-    return SGD, Adagrad, Adadelta, Adam, RMSprop
+    return SGD, Adagrad, Adadelta, Adam, Adamax, RMSprop

--- a/keras/backend/mxnet_backend.py
+++ b/keras/backend/mxnet_backend.py
@@ -4719,16 +4719,19 @@ def get_optimizers():
             return dict(list(base_config.items()) + list(config.items()))
 
     class Adamax(MXOptimizer, mx.optimizer.Adamax):
-        def __init__(self, learning_rate=0.002, beta1=0.9, beta2=0.999, decay=0., **kwargs):
-            mx.optimizer.Adamax.__init__(self, learning_rate=learning_rate, beta1=beta1, beta2=beta2,
-                                         **kwargs)
-            MXOptimizer.__init__(self, learning_rate, decay)
+        def __init__(self, lr=0.002, beta_1=0.9, beta_2=0.999, decay=0., clipnorm=None,
+                     epsilon=1e-8, **kwargs):
+            mx.optimizer.Adamax.__init__(self, learning_rate=lr, beta1=beta_1, beta2=beta_2,
+                                         clip_gradient=clipnorm, **kwargs)
+            MXOptimizer.__init__(self, lr, decay)
+            self.epsilon = epsilon
 
         def get_config(self):
             config = {'lr': float(get_value(self.learning_rate)),
                       'beta_1': float(get_value(self.beta1)),
                       'beta_2': float(get_value(self.beta2)),
-                      'decay': float(get_value(self.decay))}
+                      'decay': float(get_value(self.decay)),
+                      'epsilon': self.epsilon}
             base_config = super(Adamax, self).get_config()
             return dict(list(base_config.items()) + list(config.items()))
 

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -684,7 +684,7 @@ class TFOptimizer(Optimizer):
 
 
 if K.backend() == 'mxnet':
-    SGD, Adagrad, Adadelta, Adam, RMSprop = K.get_optimizers()
+    SGD, Adagrad, Adadelta, Adam, Adamax, RMSprop = K.get_optimizers()
 
 
 # Aliases.

--- a/keras/optimizers.py
+++ b/keras/optimizers.py
@@ -684,7 +684,7 @@ class TFOptimizer(Optimizer):
 
 
 if K.backend() == 'mxnet':
-    SGD, Adagrad, Adadelta, Adam, Adamax, RMSprop = K.get_optimizers()
+    SGD, Adagrad, Adadelta, Adam, Adamax, RMSprop, Nadam = K.get_optimizers()
 
 
 # Aliases.

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -130,9 +130,10 @@ def test_adam():
     _test_optimizer(optimizers.Adam(decay=1e-3))
 
 
-# https://github.com/deep-learning-tools/keras/issues/27
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support Adamax optimizer yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_adamax():
     _test_optimizer(optimizers.Adamax())

--- a/tests/keras/optimizers_test.py
+++ b/tests/keras/optimizers_test.py
@@ -140,9 +140,10 @@ def test_adamax():
     _test_optimizer(optimizers.Adamax(decay=1e-3))
 
 
-# https://github.com/deep-learning-tools/keras/issues/27
 @pytest.mark.skipif(K.backend() == 'mxnet',
-                    reason='MXNet backend does not support NAdam optimizer yet.')
+                    reason='MXNet backend does not support constraints. '
+                           'Keyword arguments such as `kernel_constraint` '
+                           'and `bias_constraint`')
 @keras_test
 def test_nadam():
     _test_optimizer(optimizers.Nadam())


### PR DESCRIPTION
* Adding support for NAdam and Adamax optimizer for MXNet backend.
* Keras test cases pass for these optimizer.
* Cannot enable test cases because, it includes "constraints" for variables functionality, which is not supported by MXNet backend and tracked at - https://github.com/deep-learning-tools/keras/issues/18

@deep-learning-tools/aws-deep-learning-team 